### PR TITLE
Remove @cjpatton from acknowledgements

### DIFF
--- a/draft-smyslov-ipsecme-ikev2-downgrade-prevention.xml
+++ b/draft-smyslov-ipsecme-ikev2-downgrade-prevention.xml
@@ -284,7 +284,7 @@ ResponderSignedOctets = RealMessage2 | RealMessage1
         </section>
 
         <section anchor="ack" title="Acknowledgements">
-            <t> The attack was originally described by Christopher Patton.
+            <t> TODO
             </t>
         </section>
 


### PR DESCRIPTION
Now that I'm an author, it's a little weird to also be in acknowledgements. Leave the Acknowledgements section where it is, but add a TODO in case we want to acknowledge anyone else in the document.