### PR TITLE
Run spell checker (ispell)

### DIFF
--- a/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
+++ b/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
@@ -393,7 +393,7 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
             pre-shared keys (PSK). IKEv2 allows that each peer use its own PSK when computing the content
             of the AUTH payload, so that each peer has two PSKs - one is used to create its AUTH payload
             and the other is used to verify the received AUTH payload. If these PSKs are different and an attacker
-            knows only one of them, then the abovementioned condition is satisfied and the downgrade 
+            knows only one of them, then the aforementioned condition is satisfied and the downgrade 
             prevention mechanism works.
             </t>
 


### PR DESCRIPTION
No issues, but ispell didn't recognize "abovementioned". Replaced with the more common "aforementioned".