### PR TITLE
Clarify PSK identity binding

### DIFF
--- a/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
+++ b/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
@@ -393,8 +393,10 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
             pre-shared keys (PSK). IKEv2 allows that each peer use its own PSK when computing the content
             of the AUTH payload, so that each peer has two PSKs - one is used to create its AUTH payload
             and the other is used to verify the received AUTH payload. If these PSKs are different and an attacker
-            knows only one of them, then the abovementioned condition is satisfied and the downgrade 
-            prevention mechanism works.
+            knows only one of them, then the abovementioned condition is satisfied and the downgrade
+            prevention mechanism works. This assumes that the distinct PSKs are selected and verified as
+            peer- and direction-specific authentication credentials; merely configuring different PSK values
+            without binding them to the corresponding peer identities is not sufficient for this condition.
             </t>
 
             <t> However, if these PSKs are the same and this fact as well as the PSK value are known to the attacker,

--- a/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
+++ b/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
@@ -393,7 +393,7 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
             pre-shared keys (PSK). IKEv2 allows that each peer use its own PSK when computing the content
             of the AUTH payload, so that each peer has two PSKs - one is used to create its AUTH payload
             and the other is used to verify the received AUTH payload. If these PSKs are different and an attacker
-            knows only one of them, then the abovementioned condition is satisfied and the downgrade
+            knows only one of them, then the aforementioned condition is satisfied and the downgrade
             prevention mechanism works. This assumes that the distinct PSKs are selected and verified as
             peer- and direction-specific authentication credentials; merely configuring different PSK values
             without binding them to the corresponding peer identities is not sufficient for this condition.


### PR DESCRIPTION
This is a small follow-up to the PSK authentication discussion in the Security Considerations.

The current text says downgrade prevention can still work when distinct PSKs are used and the attacker knows only one of them. This PR keeps that logic unchanged, but makes the implicit binding condition explicit: the distinct PSKs need to be selected and verified as peer- and direction-specific authentication credentials. Merely configuring different PSK byte strings without binding them to the corresponding peer identities is not enough for the stated condition.

This matches the existing text later in the paragraph that the relevant condition is not just inequality of PSK values, but whether at least one relevant authentication credential remains unavailable to the attacker in the protocol run.

Validation:

- `xmllint --noout draft-ietf-ipsecme-ikev2-downgrade-prevention.xml` passes.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` passes. The repository XML uses CRLF line endings, so `cr-at-eol` is enabled for the whitespace check.
