### PR TITLE
Address ADs' comments on the normative references

### DIFF
--- a/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
+++ b/draft-ietf-ipsecme-ikev2-downgrade-prevention.xml
@@ -376,7 +376,7 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
                 <t> The Intermediate Exchange in the Internet Key Exchange Protocol Version 2 (IKEv2) <xref target="RFC9242" /> also modifies blocks of data to be signed (or MAC'ed).
                 This modification is described in Section 3.3.2 of <xref target="RFC9242" /> and can be
                 summarized as an addition of a new piece of data (IntAuth) to the end of the blocks of data from Section 2.15 of IKEv2 <xref target="RFC7296" />.
-                If peers support the extension defined in this document, then they <bcp14>MUST</bcp14> treat modified blocks of data to be signed (or MAC'ed)
+                If peers support the extension defined in this document, then they treat modified blocks of data to be signed (or MAC'ed)
                 defined in <xref target="protocol" /> as replacements for blocks of data defined in Section 2.15 of IKEv2 <xref target="RFC7296" />,
                 so that in case of IKE_INTERMEDIATE the IntAuth is added to these modified blocks.
                 </t>
@@ -394,8 +394,8 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
                 "re-negotiated at the time of resumption".
                 </t>
 
-                <t>The information of whether an implementation used the new authentication logic for old SA <bcp14>MUST</bcp14> be stored
-                in the ticket and the implementation <bcp14>MUST</bcp14> act the same way when doing resumption.
+                <t>The information of whether an implementation used the new authentication logic for old SA ought to be saved
+                in the ticket so that the implementation retrieve it from there and act the same way when doing resumption.
                 This means that in the IKE_SESSION_RESUME exchange peers do not send the IKE_SA_INIT_FULL_TRANSCRIPT_AUTH notification
                 and do not expect it in the received messages.
                 </t>
@@ -408,10 +408,6 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
                     </t>
                 </aside>
 
-                <t>If there is a chance that the state of this feature can be changed during SA inactivity
-                (e.g., a host is upgraded or its configuration was changed), it is <bcp14>RECOMMENDED</bcp14>
-                that the host does not use IKE SA resumption and does a full handshake instead.
-                </t>
             </section>
         </section>
 
@@ -419,6 +415,10 @@ ResponderSignedOctets = ZeroPrefix | RealMessage1
             <t> Deployments that rely on this mechanism for downgrade resistance
             should provide a local policy to require successful negotiation of
             this extension and to abort the connection otherwise.
+            </t>
+
+            <t>In case the state of this feature is changed (e.g., a host is upgraded or its configuration was changed), 
+            performing a full IKEv2 handshake, instead of IKE session resumption <xref target="RFC5723" />, is <bcp14>RECOMMENDED</bcp14>.
             </t>
         </section>
 


### PR DESCRIPTION
Several ADs complain that references to Intermediate exchange (RFC9242) and IKE resumption (RFC5723) are informative, while some RFC2119 language is used for them.

I'd rather keep these references informative rather than making them normative. From my point of view, it is absolutely possible to implement this extension without reading these RFCs if an implementation does not support them. So, I tried to remove RFC2119 language there.

I also moved recommendadtion to use full handshake instead of session resumption to Operational Considerations.